### PR TITLE
StructureProvider interface

### DIFF
--- a/core/src/Structure.ts
+++ b/core/src/Structure.ts
@@ -1,4 +1,4 @@
-import { NamedNbtTag, NbtTag, getTag, getListTag, getOptional } from "@webmc/nbt";
+import { NamedNbtTag, getTag, getListTag, getOptional } from "@webmc/nbt";
 import { BlockState } from "./BlockState";
 import { StructureProvider, BlockPos, BlockNbt } from "./StructureProvider";
 

--- a/core/src/Structure.ts
+++ b/core/src/Structure.ts
@@ -1,11 +1,8 @@
 import { NamedNbtTag, NbtTag, getTag, getListTag, getOptional } from "@webmc/nbt";
 import { BlockState } from "./BlockState";
+import { StructureProvider, BlockPos, BlockNbt } from "./StructureProvider";
 
-export type BlockPos = [number, number, number]
-
-export type BlockNbt = { [key: string]: NbtTag }
-
-export class Structure {
+export class Structure implements StructureProvider {
   constructor(
     private size: BlockPos,
     private palette: BlockState[] = [],

--- a/core/src/StructureProvider.ts
+++ b/core/src/StructureProvider.ts
@@ -1,0 +1,11 @@
+import { NbtTag } from "@webmc/nbt";
+import { BlockState } from "./BlockState";
+
+export type BlockPos = [number, number, number]
+export type BlockNbt = { [key: string]: NbtTag }
+
+export interface StructureProvider{
+    getSize(): BlockPos
+    getBlocks(): {pos: BlockPos; state: BlockState; nbt: BlockNbt | undefined;}[]
+    getBlock(pos: BlockPos):  {pos: BlockPos; state: BlockState; nbt: BlockNbt | undefined;} | null
+}

--- a/core/src/StructureProvider.ts
+++ b/core/src/StructureProvider.ts
@@ -4,8 +4,8 @@ import { BlockState } from "./BlockState";
 export type BlockPos = [number, number, number]
 export type BlockNbt = { [key: string]: NbtTag }
 
-export interface StructureProvider{
-    getSize(): BlockPos
-    getBlocks(): {pos: BlockPos; state: BlockState; nbt: BlockNbt | undefined;}[]
-    getBlock(pos: BlockPos):  {pos: BlockPos; state: BlockState; nbt: BlockNbt | undefined;} | null
+export interface StructureProvider {
+  getSize(): BlockPos
+  getBlocks(): { pos: BlockPos; state: BlockState; nbt: BlockNbt | undefined }[]
+  getBlock(pos: BlockPos): { pos: BlockPos; state: BlockState; nbt: BlockNbt | undefined } | null
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./BlockState"
 export * from "./Structure"
+export * from "./StructureProvider"

--- a/render/src/StructureRenderer.ts
+++ b/render/src/StructureRenderer.ts
@@ -3,7 +3,7 @@ import { BlockAtlas } from "./BlockAtlas";
 import { BlockModelProvider } from "./BlockModel";
 import { BlockDefinitionProvider } from "./BlockDefinition";
 import { mergeFloat32Arrays, transformVectors } from "./Util";
-import { Structure } from "@webmc/core";
+import { StructureProvider } from "@webmc/core";
 import { ShaderProgram } from "./ShaderProgram";
 import { SpecialRenderer, SpecialRenderers } from "./SpecialRenderer";
 
@@ -118,7 +118,7 @@ export class StructureRenderer {
     private blockDefinitionProvider: BlockDefinitionProvider,
     private blockModelProvider: BlockModelProvider, 
     private blockAtlas: BlockAtlas,
-    private structure: Structure
+    private structure: StructureProvider
   ) {
     this.shaderProgram = new ShaderProgram(gl, vsSource, fsSource).getProgram()
     this.gridShaderProgram = new ShaderProgram(gl, vsGrid, fsGrid).getProgram()
@@ -133,7 +133,7 @@ export class StructureRenderer {
     this.initialize()
   }
 
-  public setStructure(structure: Structure) {
+  public setStructure(structure: StructureProvider) {
     this.structure = structure
     this.structureBuffers = this.getStructureBuffers()
     this.gridBuffers = this.getGridBuffers()


### PR DESCRIPTION
This adds a ```StructureProvider``` interface in core. The ```Structure``` class implements this interface. The ```StructureRenderer``` now only requires an object of type ```StructureProvider```.

This makes it easier to provide blocks from a different source for rendering to the Renderer. Without this interface any class extending ```Structure``` includes blocks array which might not be needed.