### PR TITLE
Fixed Transparency in Shader

### DIFF
--- a/render/src/StructureRenderer.ts
+++ b/render/src/StructureRenderer.ts
@@ -35,6 +35,7 @@ const fsSource = `
 
   void main(void) {
     vec4 texColor = texture2D(sampler, vTexCoord);
+    if(texColor.a < 0.01) discard;
     gl_FragColor = vec4(texColor.xyz * vTintColor, texColor.a);
   }
 `;


### PR DESCRIPTION
This is a one line fix for most transparency issues.

Most issues arise from wrong rendering order. If a semi transparent fragment is rendered before a fragment behind, the back fragment is not rendered at all because the depth buffer is already at a lower value. A proper fix for this is difficult.

However, in Minecraft most transparent pixels are completely transparent (`alpha=0`). If we just discard these fragments, the depth buffer isn't updates and fragments behind can still be rendered. 

Obviously this does not fix stained glass and water that actually have half transparency.