### PR TITLE
Chunked buffers

### DIFF
--- a/render/src/StructureRenderer.ts
+++ b/render/src/StructureRenderer.ts
@@ -172,10 +172,6 @@ export class StructureRenderer {
     this.invisibleBlockBuffers = this.getInvisibleBlockBuffers()
   }
 
-  public updateRendering(chunkPositions?: vec3[]){
-    this.updateStructureBuffers(chunkPositions)
-  }
-
   private initialize() {
     this.gl.enable(this.gl.DEPTH_TEST)
     this.gl.depthFunc(this.gl.LEQUAL)
@@ -226,7 +222,7 @@ export class StructureRenderer {
     return this.chunks[x][y][z]
   }  
 
-  private updateStructureBuffers(chunkPositions?: vec3[]): void {
+  public updateStructureBuffers(chunkPositions?: vec3[]): void {
 
     const pushBuffers = (buffers: any, pos: vec3, chunk: Chunk) => {
       const t = mat4.create()

--- a/render/src/StructureRenderer.ts
+++ b/render/src/StructureRenderer.ts
@@ -127,7 +127,6 @@ export class StructureRenderer {
 
   private chunks: Chunk[][][] = []
 
-//  private structureBuffers: StructureBuffers[][][] = []
   private gridBuffers: GridBuffers
   private outlineBuffers: GridBuffers
   private invisibleBlockBuffers: GridBuffers

--- a/render/src/StructureRenderer.ts
+++ b/render/src/StructureRenderer.ts
@@ -286,7 +286,7 @@ export class StructureRenderer {
       const blockName = b.state.getName()
       const blockProps = b.state.getProperties()
 
-      const chunkPos:vec3 = [Math.floor(b.pos[0]/16), Math.floor(b.pos[1]/16), Math.floor(b.pos[2]/16)]
+      const chunkPos:vec3 = [Math.floor(b.pos[0]/this.chunkSize), Math.floor(b.pos[1]/this.chunkSize), Math.floor(b.pos[2]/this.chunkSize)]
 
       if (chunkPositions && !chunkPositions.some(pos => vec3.equals(pos, chunkPos)))
         continue
@@ -294,8 +294,6 @@ export class StructureRenderer {
       const chunk = this.getChunk(chunkPos)
 
       try {
-        const blockProperties = this.resources.blockProperties?.getBlockProperties(blockName)
-
         const cull: Cull = {
           up: this.resources.blockProperties.getBlockProperties(this.structure.getBlock([b.pos[0], b.pos[1]+1, b.pos[2]])?.state.getName())?.opaque,
           down: this.resources.blockProperties.getBlockProperties(this.structure.getBlock([b.pos[0], b.pos[1]-1, b.pos[2]])?.state.getName())?.opaque,


### PR DESCRIPTION
For my jigsaw preview tool I need to be able to update some parts of the structure without rebuilding all buffers for performance reasons. This pull request enables that by splitting the blocks into buffers according to the position of the blocks.

The blocks are split into (by default) 16x16x16 block groups and each group uses a separate set of buffers. For that `getStructureBuffers` is renamed to `updateStructureBuffers` and updates the buffers directly instead of returning them. `updateStructureBuffers` is now a public method and takes an optional argument `chunkPositions` that specifies the chunks to update. If `chunkPosition` is not specified all chunks are updated. 

As I have started implementing this before you introduced the `getInvisibleBlockBuffers` function these are not included in the chunks yet. If you are interrested in these changes, I'd try to integrate them in the next few days.